### PR TITLE
Cleanup and support downloading message attachments

### DIFF
--- a/archive_group.py
+++ b/archive_group.py
@@ -247,11 +247,15 @@ def archive_attachments(groupName, msgNumber):
                 with open(savePath, "wb") as f:
                     f.write(r.content)
                     print("Saved attachment: {}".format(savePath))
+            else:
+                return False
 
 
 def archive_message(groupName, msgNumber):
     if saveAttachments:
-        archive_attachments(groupName, msgNumber)
+        success = archive_attachments(groupName, msgNumber)
+        if not success:
+            return False
 
     resp = make_request(
         groupName,

--- a/archive_group.py
+++ b/archive_group.py
@@ -1,4 +1,4 @@
-'''
+"""
 Yahoo-Groups-Archiver Copyright 2015, 2017, 2018 Andrew Ferguson and others
 
 YahooGroups-Archiver, a simple python script that allows for all
@@ -16,128 +16,182 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
-'''
+"""
 
-cookie_T = 'COOKIE_T_DATA_GOES_HERE'
-cookie_Y = 'COOKIE_Y_DATA_GOES_HERE'
+cookie_T = "COOKIE_T_DATA_GOES_HERE"
+cookie_Y = "COOKIE_Y_DATA_GOES_HERE"
 
-import json #required for reading various JSON attributes from the content
-import requests #required for fetching the raw messages
-import os #required for checking if a file exists locally
-import time #required if Yahoo blocks access temporarily (to wait)
-import sys #required to cancel script if blocked by Yahoo
-import shutil #required for deletung an old folder
-import glob #required to find the most recent message downloaded
-import time #required to log the date and time of run
+import json  # required for reading various JSON attributes from the content
+import requests  # required for fetching the raw messages
+import os  # required for checking if a file exists locally
+import time  # required if Yahoo blocks access temporarily (to wait)
+import sys  # required to cancel script if blocked by Yahoo
+import shutil  # required for deletung an old folder
+import glob  # required to find the most recent message downloaded
+import time  # required to log the date and time of run
+
 
 def archive_group(groupName, mode="update"):
-	log("\nArchiving group '" + groupName + "', mode: " + mode + " , on " + time.strftime("%c"), groupName)
-	startTime = time.time()
-	msgsArchived = 0
-	if mode == "retry":
-		#don't archive any messages we already have
-		#but try to archive ones that we don't, and may have
-		#already attempted to archive
-		min = 1
-	elif mode == "update":
-		#start archiving at the last+1 message message we archived
-		mostRecent = 1
-		if os.path.exists(groupName):
-			oldDir = os.getcwd()
-			os.chdir(groupName)
-			for file in glob.glob("*.json"):
-				if int(file[0:-5]) > mostRecent:
-					mostRecent = int(file[0:-5])
-			os.chdir(oldDir)
-		
-		min = mostRecent
-	elif mode == "restart":
-		#delete all previous archival attempts and archive everything again
-		if os.path.exists(groupName):
-			shutil.rmtree(groupName)
-		min = 1
-		
-	else:
-		print ("You have specified an invalid mode (" + mode + ").")
-		print ("Valid modes are:\nupdate - add any new messages to the archive\nretry - attempt to get all messages that are not in the archive\nrestart - delete archive and start from scratch")
-		sys.exit()
-	
-	if not os.path.exists(groupName):
-		os.makedirs(groupName)
-	max = group_messages_max(groupName)
-	for x in range(min,max+1):
-		if not os.path.isfile(groupName + '/' + str(x) + ".json"):
-			print ("Archiving message " + str(x) + " of " + str(max))
-			sucsess = archive_message(groupName, x)
-			if sucsess == True:
-				msgsArchived = msgsArchived + 1
-	
-	log("Archive finished, archived " + str(msgsArchived) + ", time taken is " + str(time.time() - startTime) + " seconds", groupName)
-		
+    log(
+        "\nArchiving group '"
+        + groupName
+        + "', mode: "
+        + mode
+        + " , on "
+        + time.strftime("%c"),
+        groupName,
+    )
+    startTime = time.time()
+    msgsArchived = 0
+    if mode == "retry":
+        # don't archive any messages we already have
+        # but try to archive ones that we don't, and may have
+        # already attempted to archive
+        min = 1
+    elif mode == "update":
+        # start archiving at the last+1 message message we archived
+        mostRecent = 1
+        if os.path.exists(groupName):
+            oldDir = os.getcwd()
+            os.chdir(groupName)
+            for file in glob.glob("*.json"):
+                if int(file[0:-5]) > mostRecent:
+                    mostRecent = int(file[0:-5])
+            os.chdir(oldDir)
+
+        min = mostRecent
+    elif mode == "restart":
+        # delete all previous archival attempts and archive everything again
+        if os.path.exists(groupName):
+            shutil.rmtree(groupName)
+        min = 1
+
+    else:
+        print("You have specified an invalid mode (" + mode + ").")
+        print(
+            "Valid modes are:\nupdate - add any new messages to the archive\nretry - attempt to get all messages that are not in the archive\nrestart - delete archive and start from scratch"
+        )
+        sys.exit()
+
+    if not os.path.exists(groupName):
+        os.makedirs(groupName)
+    max = group_messages_max(groupName)
+    for x in range(min, max + 1):
+        if not os.path.isfile(groupName + "/" + str(x) + ".json"):
+            print("Archiving message " + str(x) + " of " + str(max))
+            sucsess = archive_message(groupName, x)
+            if sucsess == True:
+                msgsArchived = msgsArchived + 1
+
+    log(
+        "Archive finished, archived "
+        + str(msgsArchived)
+        + ", time taken is "
+        + str(time.time() - startTime)
+        + " seconds",
+        groupName,
+    )
+
 
 def group_messages_max(groupName):
-	s = requests.Session()
-	resp = s.get('https://groups.yahoo.com/api/v1/groups/' + groupName + '/messages?count=1&sortOrder=desc&direction=-1', cookies={'T': cookie_T, 'Y': cookie_Y})
-	try:
-		pageHTML = resp.text
-		pageJson = json.loads(pageHTML)
-	except ValueError:
-		if "Stay signed in" in pageHTML and "Trouble signing in" in pageHTML:
-			#the user needs to be signed in to Yahoo
-			print ("Error. The group you are trying to archive is a private group. To archive a private group using this tool, login to a Yahoo account that has access to the private groups, then extract the data from the cookies Y and T from the domain yahoo.com . Paste this data into the appropriate variables (cookie_Y and cookie_T) at the top of this script, and run the script again.")
-			sys.exit()
-	return pageJson["ygData"]["totalRecords"]
+    s = requests.Session()
+    resp = s.get(
+        "https://groups.yahoo.com/api/v1/groups/"
+        + groupName
+        + "/messages?count=1&sortOrder=desc&direction=-1",
+        cookies={"T": cookie_T, "Y": cookie_Y},
+    )
+    try:
+        pageHTML = resp.text
+        pageJson = json.loads(pageHTML)
+    except ValueError:
+        if "Stay signed in" in pageHTML and "Trouble signing in" in pageHTML:
+            # the user needs to be signed in to Yahoo
+            print(
+                "Error. The group you are trying to archive is a private group. To archive a private group using this tool, login to a Yahoo account that has access to the private groups, then extract the data from the cookies Y and T from the domain yahoo.com . Paste this data into the appropriate variables (cookie_Y and cookie_T) at the top of this script, and run the script again."
+            )
+            sys.exit()
+    return pageJson["ygData"]["totalRecords"]
+
 
 def archive_message(groupName, msgNumber, depth=0):
-	global failed
-	failed = False
-	s = requests.Session()
-	resp = s.get('https://groups.yahoo.com/api/v1/groups/' + groupName + '/messages/' + str(msgNumber) + '/raw', cookies={'T': cookie_T, 'Y': cookie_Y})
-	if resp.status_code != 200:
-		#some other problem, perhaps being refused access by Yahoo?
-		#retry for a max of 3 times anyway
-		if depth < 3:
-			print ("Cannot get message " + str(msgNumber) + ", attempt " + str(depth+1) + " of 3 due to HTTP status code " + str(resp.status_code))
-			time.sleep(0.1)
-			archive_message(groupName,msgNumber,depth+1)
-		else:
-			if resp.status_code == 500:
-				#we are most likely being blocked by Yahoo
-				log("Archive halted - it appears Yahoo has blocked you.", groupName)
-				log("Check if you can access the group's homepage from your browser. If you can't, you have been blocked.", groupName)
-				log("Don't worry, in a few hours (normally less than 3) you'll be unblocked and you can run this script again - it'll continue where you left off." ,groupName)
-				sys.exit()
-			log("Failed to retrive message " + str(msgNumber) + " due to HTTP status code " + str(resp.status_code), groupName )
-			failed = True
-	
-	if failed == True:
-		return False
-	
-	msgJson = resp.text
-	writeFile = open((groupName + "/" + str(msgNumber) + ".json"), "wb")
-	writeFile.write(msgJson.encode('utf-8'))
-	writeFile.close()
-	return True
-			
+    global failed
+    failed = False
+    s = requests.Session()
+    resp = s.get(
+        "https://groups.yahoo.com/api/v1/groups/"
+        + groupName
+        + "/messages/"
+        + str(msgNumber)
+        + "/raw",
+        cookies={"T": cookie_T, "Y": cookie_Y},
+    )
+    if resp.status_code != 200:
+        # some other problem, perhaps being refused access by Yahoo?
+        # retry for a max of 3 times anyway
+        if depth < 3:
+            print(
+                "Cannot get message "
+                + str(msgNumber)
+                + ", attempt "
+                + str(depth + 1)
+                + " of 3 due to HTTP status code "
+                + str(resp.status_code)
+            )
+            time.sleep(0.1)
+            archive_message(groupName, msgNumber, depth + 1)
+        else:
+            if resp.status_code == 500:
+                # we are most likely being blocked by Yahoo
+                log("Archive halted - it appears Yahoo has blocked you.", groupName)
+                log(
+                    "Check if you can access the group's homepage from your browser. If you can't, you have been blocked.",
+                    groupName,
+                )
+                log(
+                    "Don't worry, in a few hours (normally less than 3) you'll be unblocked and you can run this script again - it'll continue where you left off.",
+                    groupName,
+                )
+                sys.exit()
+            log(
+                "Failed to retrive message "
+                + str(msgNumber)
+                + " due to HTTP status code "
+                + str(resp.status_code),
+                groupName,
+            )
+            failed = True
+
+    if failed == True:
+        return False
+
+    msgJson = resp.text
+    writeFile = open((groupName + "/" + str(msgNumber) + ".json"), "wb")
+    writeFile.write(msgJson.encode("utf-8"))
+    writeFile.close()
+    return True
+
 
 global writeLogFile
+
+
 def log(msg, groupName):
-	print (msg)
-	if writeLogFile:
-		logF = open(groupName + ".txt", "a")
-		logF.write("\n" + msg)
-		logF.close()
+    print(msg)
+    if writeLogFile:
+        logF = open(groupName + ".txt", "a")
+        logF.write("\n" + msg)
+        logF.close()
 
 
 if __name__ == "__main__":
-	global writeLogFile
-	writeLogFile = True
-	os.chdir(os.path.dirname(os.path.abspath(__file__)))
-	if "nologs" in sys.argv:
-		print ("Logging mode OFF")
-		writeLogFile = False
-		sys.argv.remove("nologs")
-	if len(sys.argv) > 2:
-		archive_group(sys.argv[1], sys.argv[2])
-	else:
-		archive_group(sys.argv[1])
+    global writeLogFile
+    writeLogFile = True
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    if "nologs" in sys.argv:
+        print("Logging mode OFF")
+        writeLogFile = False
+        sys.argv.remove("nologs")
+    if len(sys.argv) > 2:
+        archive_group(sys.argv[1], sys.argv[2])
+    else:
+        archive_group(sys.argv[1])

--- a/archive_group.py
+++ b/archive_group.py
@@ -243,11 +243,11 @@ def archive_attachments(groupName, msgNumber):
             print("Attachment {} already exists.".format(savePath))
         else:
             r = make_request(groupName, url, headers={"referer": msgUrl})
-            if r.statusCode == 200:
+            if r.status_code == 200:
                 with open(savePath, "wb") as f:
                     f.write(r.content)
                     print("Saved attachment: {}".format(savePath))
-            elif r.statusCode in (404,):
+            elif r.status_code in (404,):
                 # Some times, attachments just aren't there.  We don't want that to
                 # trigger a False return value
                 pass

--- a/archive_group.py
+++ b/archive_group.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 Yahoo-Groups-Archiver Copyright 2015, 2017, 2018 Andrew Ferguson and others
 

--- a/archive_group.py
+++ b/archive_group.py
@@ -224,7 +224,7 @@ def archive_attachments(groupName, msgNumber):
 
     # Loop through any anchor tags that match the appropriate patterns.
     href_pat = re.compile(r'href="(https://xa.yimg.com/kq/groups/.+?\?download=1)"')
-    filename_pat = re.compile(r'label="Download attachment (.+?)"')
+    filename_pat = re.compile(r'label="Download (?:photo|attachment) (.+?)"')
     anchors = re.findall(re.compile(r"<a\s(.+?)>"), html)
     for a in anchors:
         m = href_pat.search(a)

--- a/make_Yearly_Text_Archive.py
+++ b/make_Yearly_Text_Archive.py
@@ -1,5 +1,5 @@
 #!/usr/local/bin/python
-'''
+"""
 Yahoo-Groups-Archiver, Text Archive Script Copyright 2019 Robert Lancaster and others
 
 YahooGroups-Archiver, a simple python script that allows for all
@@ -21,7 +21,7 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
-'''
+"""
 import email
 import HTMLParser
 import json
@@ -30,64 +30,88 @@ import sys
 from datetime import datetime
 from natsort import natsorted, ns
 
-#To avoid Unicode Issues
+# To avoid Unicode Issues
 reload(sys)
-sys.setdefaultencoding('utf-8')
+sys.setdefaultencoding("utf-8")
+
 
 def archiveYahooMessage(file, archiveFile, messageYear, format):
-     try:
-          f = open(archiveFile, 'a')
-          f.write(loadYahooMessage(file, format))
-          f.close()
-          print 'Yahoo Message: ' + file + ' archived to: archive-' + str(messageYear) + '.txt'
-     except Exception as e:
-          print 'Yahoo Message: ' + file + ' had an error:'
-          print e
+    try:
+        f = open(archiveFile, "a")
+        f.write(loadYahooMessage(file, format))
+        f.close()
+        print "Yahoo Message: " + file + " archived to: archive-" + str(
+            messageYear
+        ) + ".txt"
+    except Exception as e:
+        print "Yahoo Message: " + file + " had an error:"
+        print e
+
 
 def loadYahooMessage(file, format):
-    f1 = open(file,'r')
-    fileContents=f1.read()
+    f1 = open(file, "r")
+    fileContents = f1.read()
     f1.close()
     jsonDoc = json.loads(fileContents)
-    emailMessageID = jsonDoc['ygData']['msgId']
-    emailMessageSender = HTMLParser.HTMLParser().unescape(jsonDoc['ygData']['from']).decode(format).encode('utf-8')
-    emailMessageTimeStamp = jsonDoc['ygData']['postDate']
-    emailMessageDateTime = datetime.fromtimestamp(float(emailMessageTimeStamp)).strftime('%Y-%m-%d %H:%M:%S')
-    emailMessageSubject = HTMLParser.HTMLParser().unescape(jsonDoc['ygData']['subject']).decode(format).encode('utf-8')
-    emailMessageString = HTMLParser.HTMLParser().unescape(jsonDoc['ygData']['rawEmail']).decode(format).encode('utf-8')
+    emailMessageID = jsonDoc["ygData"]["msgId"]
+    emailMessageSender = (
+        HTMLParser.HTMLParser()
+        .unescape(jsonDoc["ygData"]["from"])
+        .decode(format)
+        .encode("utf-8")
+    )
+    emailMessageTimeStamp = jsonDoc["ygData"]["postDate"]
+    emailMessageDateTime = datetime.fromtimestamp(
+        float(emailMessageTimeStamp)
+    ).strftime("%Y-%m-%d %H:%M:%S")
+    emailMessageSubject = (
+        HTMLParser.HTMLParser()
+        .unescape(jsonDoc["ygData"]["subject"])
+        .decode(format)
+        .encode("utf-8")
+    )
+    emailMessageString = (
+        HTMLParser.HTMLParser()
+        .unescape(jsonDoc["ygData"]["rawEmail"])
+        .decode(format)
+        .encode("utf-8")
+    )
     message = email.message_from_string(emailMessageString)
     messageBody = getEmailBody(message)
-    
-    messageText = '-----------------------------------------------------------------------------------\n'
-    messageText += 'Post ID:' + str(emailMessageID) + '\n'
-    messageText += 'Sender:' + emailMessageSender + '\n'
-    messageText += 'Post Date/Time:' + emailMessageDateTime + '\n'
-    messageText += 'Subject:' + emailMessageSubject + '\n'
-    messageText += 'Message:' + '\n\n'
+
+    messageText = "-----------------------------------------------------------------------------------\n"
+    messageText += "Post ID:" + str(emailMessageID) + "\n"
+    messageText += "Sender:" + emailMessageSender + "\n"
+    messageText += "Post Date/Time:" + emailMessageDateTime + "\n"
+    messageText += "Subject:" + emailMessageSubject + "\n"
+    messageText += "Message:" + "\n\n"
     messageText += messageBody
-    messageText += '\n\n\n\n\n'
+    messageText += "\n\n\n\n\n"
     return messageText
-    
+
+
 def getYahooMessageYear(file):
-    f1 = open(file,'r')
-    fileContents=f1.read()
+    f1 = open(file, "r")
+    fileContents = f1.read()
     f1.close()
     jsonDoc = json.loads(fileContents)
-    emailMessageTimeStamp = jsonDoc['ygData']['postDate']
+    emailMessageTimeStamp = jsonDoc["ygData"]["postDate"]
     return datetime.fromtimestamp(float(emailMessageTimeStamp)).year
+
 
 # Thank you to the help in this forum for the bulk of this function
 # https://stackoverflow.com/questions/17874360/python-how-to-parse-the-body-from-a-raw-email-given-that-raw-email-does-not
 
+
 def getEmailBody(message):
-    body = ''
+    body = ""
     if message.is_multipart():
         for part in message.walk():
             ctype = part.get_content_type()
-            cdispo = str(part.get('Content-Disposition'))
+            cdispo = str(part.get("Content-Disposition"))
 
             # skip any text/plain (txt) attachments
-            if ctype == 'text/plain' and 'attachment' not in cdispo:
+            if ctype == "text/plain" and "attachment" not in cdispo:
                 body += part.get_payload(decode=True)  # decode
                 break
     # not multipart - i.e. plain text, no attachments, keeping fingers crossed
@@ -95,26 +119,25 @@ def getEmailBody(message):
         body += message.get_payload(decode=True)
     return body
 
+
 ## This is where the script starts
 
 if len(sys.argv) < 2:
-     sys.exit('You need to specify your group name')
+    sys.exit("You need to specify your group name")
 
 groupName = sys.argv[1]
 oldDir = os.getcwd()
 if os.path.exists(groupName):
-    archiveDir = os.path.abspath(groupName + '-archive')
+    archiveDir = os.path.abspath(groupName + "-archive")
     if not os.path.exists(archiveDir):
-         os.makedirs(archiveDir)
+        os.makedirs(archiveDir)
     os.chdir(groupName)
     for file in natsorted(os.listdir(os.getcwd())):
-         messageYear = getYahooMessageYear(file)
-         archiveFile = archiveDir + '/archive-' + str(messageYear) + '.txt'
-         archiveYahooMessage(file, archiveFile, messageYear, 'utf-8')
+        messageYear = getYahooMessageYear(file)
+        archiveFile = archiveDir + "/archive-" + str(messageYear) + ".txt"
+        archiveYahooMessage(file, archiveFile, messageYear, "utf-8")
 else:
-     sys.exit('Please run archive-group.py first')
+    sys.exit("Please run archive-group.py first")
 
 os.chdir(oldDir)
-print('Complete')
-
-
+print ("Complete")

--- a/make_Yearly_Text_Archive.py
+++ b/make_Yearly_Text_Archive.py
@@ -40,12 +40,11 @@ def archiveYahooMessage(file, archiveFile, messageYear, format):
         f = open(archiveFile, "a")
         f.write(loadYahooMessage(file, format))
         f.close()
-        print "Yahoo Message: " + file + " archived to: archive-" + str(
-            messageYear
-        ) + ".txt"
+        print(
+            "Yahoo Message: {} archived to: archive-{}.txt".format(file, messageYear)
+        )
     except Exception as e:
-        print "Yahoo Message: " + file + " had an error:"
-        print e
+        print("Yahoo Message: {} had an error:\n{}".format(file, e))
 
 
 def loadYahooMessage(file, format):

--- a/make_Yearly_Text_Archive.py
+++ b/make_Yearly_Text_Archive.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python
 """
 Yahoo-Groups-Archiver, Text Archive Script Copyright 2019 Robert Lancaster and others
 

--- a/make_Yearly_Text_Archive_html.py
+++ b/make_Yearly_Text_Archive_html.py
@@ -1,5 +1,5 @@
 #!/usr/local/bin/python
-'''
+"""
 Yahoo-Groups-Archiver, HTML Archive Script Copyright 2019 Robert Lancaster and others
 
 YahooGroups-Archiver, a simple python script that allows for all
@@ -21,7 +21,7 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
-'''
+"""
 import email
 import HTMLParser
 import json
@@ -30,97 +30,119 @@ import sys
 from datetime import datetime
 from natsort import natsorted, ns
 
-#To avoid Unicode Issues
+# To avoid Unicode Issues
 reload(sys)
-sys.setdefaultencoding('utf-8')
+sys.setdefaultencoding("utf-8")
+
 
 def archiveYahooMessage(file, archiveFile, messageYear, format):
-     try:
-          f = open(archiveFile, 'a')
-          f.write(loadYahooMessage(file, format))
-          f.close()
-          print 'Yahoo Message: ' + file + ' archived to: archive-' + str(messageYear) + '.html'
-     except Exception as e:
-          print 'Yahoo Message: ' + file + ' had an error:'
-          print e
+    try:
+        f = open(archiveFile, "a")
+        f.write(loadYahooMessage(file, format))
+        f.close()
+        print "Yahoo Message: " + file + " archived to: archive-" + str(
+            messageYear
+        ) + ".html"
+    except Exception as e:
+        print "Yahoo Message: " + file + " had an error:"
+        print e
+
 
 def loadYahooMessage(file, format):
-    f1 = open(file,'r')
-    fileContents=f1.read()
+    f1 = open(file, "r")
+    fileContents = f1.read()
     f1.close()
     jsonDoc = json.loads(fileContents)
-    emailMessageID = jsonDoc['ygData']['msgId']
-    emailMessageSender = HTMLParser.HTMLParser().unescape(jsonDoc['ygData']['from']).decode(format).encode('utf-8')
-    emailMessageTimeStamp = jsonDoc['ygData']['postDate']
-    emailMessageDateTime = datetime.fromtimestamp(float(emailMessageTimeStamp)).strftime('%Y-%m-%d %H:%M:%S')
-    emailMessageSubject = HTMLParser.HTMLParser().unescape(jsonDoc['ygData']['subject']).decode(format).encode('utf-8')
-    emailMessageString = HTMLParser.HTMLParser().unescape(jsonDoc['ygData']['rawEmail']).decode(format).encode('utf-8')
+    emailMessageID = jsonDoc["ygData"]["msgId"]
+    emailMessageSender = (
+        HTMLParser.HTMLParser()
+        .unescape(jsonDoc["ygData"]["from"])
+        .decode(format)
+        .encode("utf-8")
+    )
+    emailMessageTimeStamp = jsonDoc["ygData"]["postDate"]
+    emailMessageDateTime = datetime.fromtimestamp(
+        float(emailMessageTimeStamp)
+    ).strftime("%Y-%m-%d %H:%M:%S")
+    emailMessageSubject = (
+        HTMLParser.HTMLParser()
+        .unescape(jsonDoc["ygData"]["subject"])
+        .decode(format)
+        .encode("utf-8")
+    )
+    emailMessageString = (
+        HTMLParser.HTMLParser()
+        .unescape(jsonDoc["ygData"]["rawEmail"])
+        .decode(format)
+        .encode("utf-8")
+    )
     message = email.message_from_string(emailMessageString)
     messageBody = getEmailBody(message)
-    
-    messageText = '-----------------------------------------------------------------------------------<br>'
-    messageText += 'Post ID:' + str(emailMessageID) + '<br>'
-    messageText += 'Sender:' + emailMessageSender + '<br>'
-    messageText += 'Post Date/Time:' + emailMessageDateTime + '<br>'
-    messageText += 'Subject:' + emailMessageSubject + '<br>'
-    messageText += 'Message:' + '<br><br>'
+
+    messageText = "-----------------------------------------------------------------------------------<br>"
+    messageText += "Post ID:" + str(emailMessageID) + "<br>"
+    messageText += "Sender:" + emailMessageSender + "<br>"
+    messageText += "Post Date/Time:" + emailMessageDateTime + "<br>"
+    messageText += "Subject:" + emailMessageSubject + "<br>"
+    messageText += "Message:" + "<br><br>"
     messageText += messageBody
-    messageText += '<br><br><br><br><br>'
+    messageText += "<br><br><br><br><br>"
     return messageText
-    
+
+
 def getYahooMessageYear(file):
-    f1 = open(file,'r')
-    fileContents=f1.read()
+    f1 = open(file, "r")
+    fileContents = f1.read()
     f1.close()
     jsonDoc = json.loads(fileContents)
-    emailMessageTimeStamp = jsonDoc['ygData']['postDate']
+    emailMessageTimeStamp = jsonDoc["ygData"]["postDate"]
     return datetime.fromtimestamp(float(emailMessageTimeStamp)).year
+
 
 # Thank you to the help in this forum for the bulk of this function
 # https://stackoverflow.com/questions/17874360/python-how-to-parse-the-body-from-a-raw-email-given-that-raw-email-does-not
 def getEmailBody(message):
-    body = ''
+    body = ""
     if message.is_multipart():
         for part in message.walk():
             ctype = part.get_content_type()
-            cdispo = str(part.get('Content-Disposition'))
+            cdispo = str(part.get("Content-Disposition"))
 
             # skip any text/plain (txt) attachments
-            if ctype == 'text/plain' and 'attachment' not in cdispo:
-                body += '<pre>'
+            if ctype == "text/plain" and "attachment" not in cdispo:
+                body += "<pre>"
                 body += part.get_payload(decode=True)  # decode
-                body += '</pre>'
+                body += "</pre>"
                 break
     # not multipart - i.e. plain text, no attachments, keeping fingers crossed
     else:
         ctype = message.get_content_type()
-        if ctype != 'text/html':
-             body += '<pre>'
+        if ctype != "text/html":
+            body += "<pre>"
         body += message.get_payload(decode=True)
-        if ctype != 'text/html':
-             body += '</pre>'
+        if ctype != "text/html":
+            body += "</pre>"
     return body
+
 
 ## This is where the script starts
 
 if len(sys.argv) < 2:
-     sys.exit('You need to specify your group name')
+    sys.exit("You need to specify your group name")
 
 groupName = sys.argv[1]
 oldDir = os.getcwd()
 if os.path.exists(groupName):
-    archiveDir = os.path.abspath(groupName + '-archive')
+    archiveDir = os.path.abspath(groupName + "-archive")
     if not os.path.exists(archiveDir):
-         os.makedirs(archiveDir)
+        os.makedirs(archiveDir)
     os.chdir(groupName)
     for file in natsorted(os.listdir(os.getcwd())):
-         messageYear = getYahooMessageYear(file)
-         archiveFile = archiveDir + '/archive-' + str(messageYear) + '.html'
-         archiveYahooMessage(file, archiveFile, messageYear, 'utf-8')
+        messageYear = getYahooMessageYear(file)
+        archiveFile = archiveDir + "/archive-" + str(messageYear) + ".html"
+        archiveYahooMessage(file, archiveFile, messageYear, "utf-8")
 else:
-     sys.exit('Please run archive-group.py first')
+    sys.exit("Please run archive-group.py first")
 
 os.chdir(oldDir)
-print('Complete')
-
-
+print ("Complete")

--- a/make_Yearly_Text_Archive_html.py
+++ b/make_Yearly_Text_Archive_html.py
@@ -40,12 +40,11 @@ def archiveYahooMessage(file, archiveFile, messageYear, format):
         f = open(archiveFile, "a")
         f.write(loadYahooMessage(file, format))
         f.close()
-        print "Yahoo Message: " + file + " archived to: archive-" + str(
-            messageYear
-        ) + ".html"
+        print(
+            "Yahoo Message: {} archived to: archive-{}.html".format(file, messageYear)
+        )
     except Exception as e:
-        print "Yahoo Message: " + file + " had an error:"
-        print e
+        print("Yahoo Message: {} had an error:\n{}".format(file, e))
 
 
 def loadYahooMessage(file, format):
@@ -145,4 +144,4 @@ else:
     sys.exit("Please run archive-group.py first")
 
 os.chdir(oldDir)
-print ("Complete")
+print("Complete")

--- a/make_Yearly_Text_Archive_html.py
+++ b/make_Yearly_Text_Archive_html.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python
 """
 Yahoo-Groups-Archiver, HTML Archive Script Copyright 2019 Robert Lancaster and others
 


### PR DESCRIPTION
I know you have an open PR against the original repo, so I thought I'd start with yours to see if maybe the both of us can get an even better solution submitted there.

* Autoformat everything with `black` to bring everything mostly up to date with pep8
  * Browsing the diff with whitespace changes hidden will lessen the churn, but the original
     code was pretty out of spec so there are a lot of line wraps and quote character changes
     that make it messy.
* Various minor fixes and compile errors (one misplaced variable meant the script didn't even run)
* Consolidates http requests into a new method that knows how to handle errors and incremental backoff.
* Most importantly: updated scraper code that knows how to find and download email attachments.

I'm still testing this code, so there may be other changes.  I will update the PR as appropriate.

I feel it's also worth discussing the differences between `retry` and `update` modes. The `retry` code smart/fast enough to make `update` a somewhat useless default (or a useless feature entirely that should be removed).